### PR TITLE
Fix following extra fields error

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -45,6 +45,12 @@ export const Course = defineDocumentType(() => ({
       type: "string",
       required: true,
     },
+    date: {
+      type: "string",
+    },
+    author: {
+      type: "string",
+    },
     description: {
       type: "string",
     },
@@ -67,6 +73,9 @@ export const Program = defineDocumentType(() => ({
       required: true,
     },
     description: {
+      type: "string",
+    },
+    ogImage: {
       type: "string",
     },
     published: {


### PR DESCRIPTION
`content/courses/html/6-cxrilebi.mdx` file is empty and causes errors
There's a warning on duplicate title(s)

Other issues have been fixed in `contentlayer.config.js` file

- Added *ogImage* field to *Program* document type
- Added *date* and *author* fields to *Course* document type